### PR TITLE
Add ConstantToServiceCallRector

### DIFF
--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -7,9 +7,11 @@ use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Folder;
+use Contao\Rector\Rector\ConstantToServiceCallRector;
 use Contao\Rector\Rector\InsertTagsServiceRector;
 use Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector;
 use Contao\Rector\Rector\SystemLanguagesToServiceRector;
+use Contao\Rector\ValueObject\ConstantToServiceCall;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToServiceCall;
 use Contao\StringUtil;
 use Patchwork\Utf8;
@@ -71,6 +73,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Contao 4.13
     $rectorConfig->rule(InsertTagsServiceRector::class);
+
+    $rectorConfig->ruleWithConfiguration(ConstantToServiceCallRector::class, [
+        new ConstantToServiceCall('REQUEST_TOKEN', 'contao.csrf.token_manager', 'getDefaultTokenValue'),
+    ]);
 
     // Contao 4.12
     //'Contao\FrontendUser::isMemberOf($ids)' => 'Contao\System::getContainer()->get(\'security.helper\')->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $ids)',

--- a/src/Rector/ConstantToServiceCallRector.php
+++ b/src/Rector/ConstantToServiceCallRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Rector;
+
+use Contao\Rector\ValueObject\ConstantToServiceCall;
+use PhpParser\Node;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class ConstantToServiceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var array<ConstantToServiceCall>
+     */
+    private array $configuration;
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ConstantToServiceCall::class);
+        $this->configuration = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated constants to service calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$requestToken = REQUEST_TOKEN;
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$requestToken = \Contao\System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+CODE_AFTER
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\ConstFetch::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\ConstFetch);
+
+        foreach ($this->configuration as $config) {
+            if ($this->isName($node->name, $config->getConstant())) {
+                $container = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Contao\System'), 'getContainer');
+                $service = new Node\Expr\MethodCall($container, 'get', [new Node\Arg(new Node\Scalar\String_($config->getServiceName()))]);
+                $method_name = new Node\Identifier($config->getServiceMethodName());
+                $node = new Node\Expr\MethodCall($service, $method_name);
+
+                return $node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ValueObject/ConstantToServiceCall.php
+++ b/src/ValueObject/ConstantToServiceCall.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\ValueObject;
+
+class ConstantToServiceCall
+{
+    public function __construct(
+        private readonly string $constant,
+        private readonly string $serviceName,
+        private readonly string $serviceMethodName
+    ) {
+    }
+
+    public function getConstant(): string
+    {
+        return $this->constant;
+    }
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+
+    public function getServiceMethodName(): string
+    {
+        return $this->serviceMethodName;
+    }
+}

--- a/tests/Rector/ConstantToServiceCallRector/ConstantToServiceCallRectorTest.php
+++ b/tests/Rector/ConstantToServiceCallRector/ConstantToServiceCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Tests\Rector\ConstantToServiceCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConstantToServiceCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/ConstantToServiceCallRector/config/config.php
+++ b/tests/Rector/ConstantToServiceCallRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\Rector\Rector\ConstantToServiceCallRector;
+use Contao\Rector\ValueObject\ConstantToServiceCall;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ConstantToServiceCallRector::class, [
+        new ConstantToServiceCall('REQUEST_TOKEN', 'contao.csrf.token_manager', 'getDefaultTokenValue')
+    ]);
+};

--- a/tests/Rector/ConstantToServiceCallRector/fixture/constants.php.inc
+++ b/tests/Rector/ConstantToServiceCallRector/fixture/constants.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $requestToken = REQUEST_TOKEN;
+    }
+}
+?>
+-----
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $requestToken = \Contao\System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+    }
+}
+?>


### PR DESCRIPTION
This PR introduces the `ConstantToServiceCallRector` that is similar to `ConstantToServiceParameterRector` and allows creating service calls such as changing 
```php
REQUEST_TOKEN
``` 
to 
```php
System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()
```