### PR TITLE
Add missing test for `ConstantToClassConstantRector`

### DIFF
--- a/tests/Rector/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
+++ b/tests/Rector/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Tests\Rector\ConstantToServiceCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConstantToClassConstantRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
+++ b/tests/Rector/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\Rector\Tests\Rector\ConstantToServiceCallRector;
+namespace Contao\Rector\Tests\Rector\ConstantToClassConstantRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Rector/ConstantToClassConstantRector/config/config.php
+++ b/tests/Rector/ConstantToClassConstantRector/config/config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\CoreBundle\Monolog\ContaoContext;
+use Contao\Rector\Rector\ConstantToClassConstantRector;
+use Contao\Rector\ValueObject\ConstantToClassConstant;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ConstantToClassConstantRector::class, [
+        new ConstantToClassConstant('TL_ACCESS', ContaoContext::class, 'ACCESS')
+    ]);
+};

--- a/tests/Rector/ConstantToClassConstantRector/fixture/constants.php.inc
+++ b/tests/Rector/ConstantToClassConstantRector/fixture/constants.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $logLevel = TL_ACCESS;
+    }
+}
+?>
+-----
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $logLevel = \Contao\CoreBundle\Monolog\ContaoContext::ACCESS;
+    }
+}
+?>


### PR DESCRIPTION
### Description

This PR adds a missing test for the `ConstantToClassConstantRector` as mentioned in https://github.com/contao/contao-rector/pull/5#issuecomment-2099077762

![image](https://github.com/contao/contao-rector/assets/55794780/aa2ce0c8-305c-4f58-940a-a476c115be91)
