### PR TITLE
Add `ReplaceDataContainerValueRector`

### DIFF
--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -13,10 +13,14 @@ use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Util\SimpleTokenParser;
+use Contao\DC_File;
+use Contao\DC_Folder;
+use Contao\DC_Table;
 use Contao\Folder;
 use Contao\Rector\Rector\ConstantToServiceCallRector;
 use Contao\Rector\Rector\InsertTagsServiceRector;
 use Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector;
+use Contao\Rector\Rector\ReplaceDataContainerRector;
 use Contao\Rector\Rector\SystemLanguagesToServiceRector;
 use Contao\Rector\ValueObject\ConstantToServiceCall;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToServiceCall;
@@ -32,6 +36,7 @@ use Rector\Transform\Rector\FuncCall\FuncCallToStaticCallRector;
 use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
 use Rector\Transform\ValueObject\FuncCallToStaticCall;
 use Rector\Transform\ValueObject\StaticCallToFuncCall;
+use Rector\Transform\ValueObject\StringToClassConstant;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -6,6 +6,7 @@ use Contao\ArrayUtil;
 use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\DC_Table;
 use Contao\Folder;
 use Contao\Rector\Rector\InsertTagsServiceRector;
 use Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector;
@@ -19,8 +20,10 @@ use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Transform\Rector\FuncCall\FuncCallToStaticCallRector;
 use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
+use Rector\Transform\Rector\String_\StringToClassConstantRector;
 use Rector\Transform\ValueObject\FuncCallToStaticCall;
 use Rector\Transform\ValueObject\StaticCallToFuncCall;
+use Rector\Transform\ValueObject\StringToClassConstant;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(FuncCallToStaticCallRector::class, [
@@ -71,6 +74,9 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Contao 4.13
     $rectorConfig->rule(InsertTagsServiceRector::class);
+    $rectorConfig->ruleWithConfiguration(StringToClassConstantRector::class, [
+        new StringToClassConstant('Table', DC_Table::class, 'class'),
+    ]);
 
     // Contao 4.12
     //'Contao\FrontendUser::isMemberOf($ids)' => 'Contao\System::getContainer()->get(\'security.helper\')->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $ids)',

--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -6,11 +6,14 @@ use Contao\ArrayUtil;
 use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\DC_File;
+use Contao\DC_Folder;
 use Contao\DC_Table;
 use Contao\Folder;
 use Contao\Rector\Rector\ConstantToServiceCallRector;
 use Contao\Rector\Rector\InsertTagsServiceRector;
 use Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector;
+use Contao\Rector\Rector\ReplaceDataContainerRector;
 use Contao\Rector\Rector\SystemLanguagesToServiceRector;
 use Contao\Rector\ValueObject\ConstantToServiceCall;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToServiceCall;
@@ -76,8 +79,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Contao 4.13
     $rectorConfig->rule(InsertTagsServiceRector::class);
-    $rectorConfig->ruleWithConfiguration(StringToClassConstantRector::class, [
+    $rectorConfig->ruleWithConfiguration(ReplaceDataContainerRector::class, [
         new StringToClassConstant('Table', DC_Table::class, 'class'),
+        new StringToClassConstant('File', DC_File::class, 'class'),
+        new StringToClassConstant('Folder', DC_Folder::class, 'class')
     ]);
 
     $rectorConfig->ruleWithConfiguration(ConstantToServiceCallRector::class, [

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,4 +1,4 @@
-# 12 Rules Overview
+# 13 Rules Overview
 
 ## ConstantToClassConstantRector
 
@@ -150,6 +150,26 @@ Fixes deprecated TL_MODE constant to service call
 ```diff
 -$isBackend = TL_MODE === 'BE';
 +$isBackend = \Contao\System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(\Contao\System::getContainer()->get('request_stack')->getCurrentRequest() ?? \Symfony\Component\HttpFoundation\Request::create(''));
+```
+
+<br>
+
+## ReplaceDataContainerRector
+
+Replaces data container strings to class constants
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\ReplaceDataContainerRector`](../src/Rector/ReplaceDataContainerRector.php)
+
+```diff
+ $GLOBALS['TL_DCA']['tl_foo'] = [
+     'config' => [
+-        'dataContainer' => 'Table',
++        'dataContainer' => \Contao\DC_Table::class,
+         //...
+     ],
+ ];
 ```
 
 <br>

--- a/src/Rector/ReplaceDataContainerRector.php
+++ b/src/Rector/ReplaceDataContainerRector.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Rector;
 
+use Contao\DC_Table;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Rector\Transform\ValueObject\StringToClassConstant;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -30,7 +31,7 @@ final class ReplaceDataContainerRector extends AbstractRector implements Configu
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Replaces data container strings to class constants', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $GLOBALS['TL_DCA']['tl_foo'] = [
     'config' => [
@@ -47,7 +48,8 @@ $GLOBALS['TL_DCA']['tl_foo'] = [
         //...
     ],
 ];
-CODE_AFTER
+CODE_AFTER,
+                [new StringToClassConstant('Table', DC_Table::class, 'class')]
             ),
         ]);
     }

--- a/src/Rector/ReplaceDataContainerRector.php
+++ b/src/Rector/ReplaceDataContainerRector.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\StringToClassConstant;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class ReplaceDataContainerRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var array<StringToClassConstant>
+     */
+    private array $configuration;
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, StringToClassConstant::class);
+        $this->configuration = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replaces data container strings to class constants', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$GLOBALS['TL_DCA']['tl_foo'] = [
+    'config' => [
+        'dataContainer' => 'Table',
+        //...
+    ],
+];
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$GLOBALS['TL_DCA']['tl_foo'] = [
+    'config' => [
+        'dataContainer' => \Contao\DC_Table::class,
+        //...
+    ],
+];
+CODE_AFTER
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            ArrayItem::class
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof ArrayItem);
+
+        if (
+            !$node->key instanceof String_
+            || 'dataContainer' !== $node->key->value
+        ) {
+            return null;
+        }
+
+        foreach ($this->configuration as $config) {
+
+            if (
+                $node->value instanceof String_
+                && $node->value->value === $config->getString()
+            ) {
+                $node->value = new Node\Expr\ClassConstFetch(
+                    new Node\Name\FullyQualified($config->getClass()),
+                    new Node\Identifier($config->getConstant())
+                );
+
+                return $node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/ReplaceDataContainerRector/ReplaceDataContainerRectorTest.php
+++ b/tests/Rector/ReplaceDataContainerRector/ReplaceDataContainerRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Tests\Rector\ReplaceDataContainerRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceDataContainerRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/ReplaceDataContainerRector/config/config.php
+++ b/tests/Rector/ReplaceDataContainerRector/config/config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\DC_File;
+use Contao\DC_Folder;
+use Contao\DC_Table;
+use Contao\Rector\Rector\ReplaceDataContainerRector;
+use Rector\Config\RectorConfig;
+use Rector\Transform\ValueObject\StringToClassConstant;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ReplaceDataContainerRector::class, [
+        new StringToClassConstant('Table', DC_Table::class, 'class'),
+        new StringToClassConstant('File', DC_File::class, 'class'),
+        new StringToClassConstant('Folder', DC_Folder::class, 'class')
+    ]);
+};

--- a/tests/Rector/ReplaceDataContainerRector/fixture/dca.php.inc
+++ b/tests/Rector/ReplaceDataContainerRector/fixture/dca.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+        $GLOBALS['TL_DCA']['tl_foo'] = [
+            'config' => [
+                'dataContainer' => 'Table'
+            ]
+        ];
+
+        $GLOBALS['TL_DCA']['tl_bar'] = [
+            'config' => [
+                'dataContainer' => 'File'
+            ]
+        ];
+
+        $GLOBALS['TL_DCA']['tl_baz'] = [
+            'config' => [
+                'dataContainer' => 'Folder'
+            ]
+        ];
+    }
+}
+?>
+-----
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+        $GLOBALS['TL_DCA']['tl_foo'] = [
+            'config' => [
+                'dataContainer' => \Contao\DC_Table::class
+            ]
+        ];
+
+        $GLOBALS['TL_DCA']['tl_bar'] = [
+            'config' => [
+                'dataContainer' => \Contao\DC_File::class
+            ]
+        ];
+
+        $GLOBALS['TL_DCA']['tl_baz'] = [
+            'config' => [
+                'dataContainer' => \Contao\DC_Folder::class
+            ]
+        ];
+    }
+}
+?>


### PR DESCRIPTION
### Description

Implements #6

_**Old:**_
```php
'config' => [
    'dataContainer' => 'Table,
    'ctable'        => ['tl_child_table'],
```

**_New:_**
```php
'config' => [
    'dataContainer' => DC_Table::class,
    'ctable'        => ['tl_child_table'],
```