### PR TITLE
Add rules overview for rectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ dependencies like PHP, Symfony and Doctrine.
 
 As an example, the **ContaoLevelSetList::UP_TO_CONTAO_413** will upgrade your code
 to PHP 7.4 and Symfony 5.4, since Contao 4.13 does not support any lower versions.
+
+## Available rules
+
+* [Explore the current Rector rules](/docs/rules_overview.md)

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,5 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
-    }
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "contao/core-bundle": "^4.4 || ^5.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "symplify/rule-doc-generator": "^12.2"
     },
     "autoload": {
         "psr-4": {
@@ -40,5 +41,10 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    }
 }

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,0 +1,183 @@
+# 12 Rules Overview
+
+## ConstantToClassConstantRector
+
+Fixes deprecated constants to class constants
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\ConstantToClassConstantRector`](../src/Rector/ConstantToClassConstantRector.php)
+
+```diff
+-$logLevel = TL_ACCESS;
++$logLevel = \Contao\CoreBundle\Monolog\ContaoContext::ACCESS;
+```
+
+<br>
+
+## ConstantToServiceCallRector
+
+Fixes deprecated constants to service calls
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\ConstantToServiceCallRector`](../src/Rector/ConstantToServiceCallRector.php)
+
+```diff
+-$requestToken = REQUEST_TOKEN;
++$requestToken = \Contao\System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+```
+
+<br>
+
+## ConstantToServiceParameterRector
+
+Fixes deprecated constants to service parameters
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\ConstantToServiceParameterRector`](../src/Rector/ConstantToServiceParameterRector.php)
+
+```diff
+-$projectDir = TL_ROOT;
++$projectDir = \Contao\System::getContainer()->getParameter('kernel.project_dir');
+```
+
+<br>
+
+## ControllerMethodToVersionsClassRector
+
+Fixes deprecated `Controller::createInitialVersion()` and `Controller::createNewVersion()` to Versions class calls
+
+- class: [`Contao\Rector\Rector\ControllerMethodToVersionsClassRector`](../src/Rector/ControllerMethodToVersionsClassRector.php)
+
+```diff
+-\Contao\Controller::createInitialVersion('tl_page', 17);
+-\Contao\Controller::createNewVersion('tl_page', 17);
++(new \Contao\Versions('tl_page', 17))->initialize();
++(new \Contao\Versions('tl_page', 17))->create();
+```
+
+<br>
+
+## InsertTagsServiceRector
+
+Fixes deprecated `Controller::replaceInsertTags()` to service calls
+
+- class: [`Contao\Rector\Rector\InsertTagsServiceRector`](../src/Rector/InsertTagsServiceRector.php)
+
+```diff
+-$buffer = \Contao\Controller::replaceInsertTags($buffer);
+-$uncached = \Contao\Controller::replaceInsertTags($buffer, false);
+-$class = (new \Contao\InsertTags())->replace($buffer);
++$buffer = \Contao\System::getContainer('contao.insert_tags.parser')->replace($buffer);
++$uncached = \Contao\System::getContainer('contao.insert_tags.parser')->replaceInline($buffer);
++$class = \Contao\System::getContainer('contao.insert_tags.parser')->replace($buffer);
+```
+
+<br>
+
+## LegacyFrameworkCallToInstanceCallRector
+
+Fixes deprecated legacy framework method to static calls
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\LegacyFrameworkCallToInstanceCallRector`](../src/Rector/LegacyFrameworkCallToInstanceCallRector.php)
+
+```diff
+-$ids = \Contao\Controller::getChildRecords([42], 'tl_page');
+-$ids = \Contao\Controller::getParentRecords(42, 'tl_page');
++$ids = \Contao\Database::getInstance()->getChildRecords([42], 'tl_page');
++$ids = \Contao\Database::getInstance()->getParentRecords(42, 'tl_page');
+```
+
+<br>
+
+## LegacyFrameworkCallToServiceCallRector
+
+Fixes deprecated legacy framework method to service calls
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector`](../src/Rector/LegacyFrameworkCallToServiceCallRector.php)
+
+```diff
+-$buffer = $this->parseSimpleTokens($buffer, $arrTokens);
++$buffer = \Contao\System::getContainer()->get('contao.string.simple_token_parser')->parse($buffer, $arrTokens);
+```
+
+<br>
+
+## LegacyFrameworkCallToStaticCallRector
+
+Fixes deprecated legacy framework method to static calls
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\LegacyFrameworkCallToStaticCallRector`](../src/Rector/LegacyFrameworkCallToStaticCallRector.php)
+
+```diff
+-$html = \Contao\Controller::getImage($image, $width, $height);
+-$html = $this->getImage($image, $width, $height);
++$html = \Contao\Image::get($image, $width, $height);
++$html = \Contao\Image::get($image, $width, $height);
+```
+
+<br>
+
+## LoginConstantsToSymfonySecurityRector
+
+Fixes deprecated login constants to security service call
+
+- class: [`Contao\Rector\Rector\LoginConstantsToSymfonySecurityRector`](../src/Rector/LoginConstantsToSymfonySecurityRector.php)
+
+```diff
+-$hasFrontendAccess = FE_USER_LOGGED_IN;
+-$hasBackendAccess = BE_USER_LOGGED_IN;
++$hasFrontendAccess = \Contao\System::getContainer()->get('security.helper')->isGranted('ROLE_MEMBER');
++$hasBackendAccess = \Contao\System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
+```
+
+<br>
+
+## ModeConstantToScopeMatcherRector
+
+Fixes deprecated TL_MODE constant to service call
+
+- class: [`Contao\Rector\Rector\ModeConstantToScopeMatcherRector`](../src/Rector/ModeConstantToScopeMatcherRector.php)
+
+```diff
+-$isBackend = TL_MODE === 'BE';
++$isBackend = \Contao\System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(\Contao\System::getContainer()->get('request_stack')->getCurrentRequest() ?? \Symfony\Component\HttpFoundation\Request::create(''));
+```
+
+<br>
+
+## SystemLanguagesToServiceRector
+
+Fixes deprecated `\Contao\System::getLanguages()` method to service call
+
+- class: [`Contao\Rector\Rector\SystemLanguagesToServiceRector`](../src/Rector/SystemLanguagesToServiceRector.php)
+
+```diff
+-$languaegs = \Contao\System::getLanguages();
++$languages = \Contao\System::getContainer()->get('contao.intl.locales')->getLocales(null, true);
+```
+
+<br>
+
+## SystemLogToMonologRector
+
+Rewrites deprecated `System::log()` calls to Monolog
+
+- class: [`Contao\Rector\Rector\SystemLogToMonologRector`](../src/Rector/SystemLogToMonologRector.php)
+
+```diff
+-\Contao\System::log('generic log message', __METHOD__, TL_ACCESS);
+-\Contao\System::log('error message', __METHOD__, TL_ERROR);
++\Contao\System::getContainer()->get('logger')->log(\Psr\Log\LogLevel::INFO, 'generic log message', ['contao' => new \Contao\CoreBundle\Monolog\ContaoContext(__METHOD__, \Contao\CoreBundle\Monolog\ContaoContext::ACCESS)]);
++\Contao\System::getContainer()->get('logger')->log(\Psr\Log\LogLevel::ERROR, 'error message', ['contao' => new \Contao\CoreBundle\Monolog\ContaoContext(__METHOD__, \Contao\CoreBundle\Monolog\ContaoContext::ERROR)]);
+```
+
+<br>

--- a/src/Rector/ConstantToClassConstantRector.php
+++ b/src/Rector/ConstantToClassConstantRector.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Rector;
 
+use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\Rector\ValueObject\ConstantToClassConstant;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -28,14 +29,15 @@ final class ConstantToClassConstantRector extends AbstractRector implements Conf
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated constants to class constants', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $logLevel = TL_ACCESS;
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
 $logLevel = \Contao\CoreBundle\Monolog\ContaoContext::ACCESS;
-CODE_AFTER
+CODE_AFTER,
+                [new ConstantToClassConstant('TL_ERROR', ContaoContext::class, 'ERROR')]
             ),
         ]);
     }

--- a/src/Rector/ConstantToServiceCallRector.php
+++ b/src/Rector/ConstantToServiceCallRector.php
@@ -7,7 +7,7 @@ namespace Contao\Rector\Rector;
 use Contao\Rector\ValueObject\ConstantToServiceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -27,14 +27,15 @@ final class ConstantToServiceCallRector extends AbstractLegacyFrameworkCallRecto
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated constants to service calls', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $requestToken = REQUEST_TOKEN;
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
 $requestToken = \Contao\System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
-CODE_AFTER
+CODE_AFTER,
+                [new ConstantToServiceCall('REQUEST_TOKEN', 'contao.csrf.token_manager', 'getDefaultTokenValue')]
             ),
         ]);
     }

--- a/src/Rector/ConstantToServiceParameterRector.php
+++ b/src/Rector/ConstantToServiceParameterRector.php
@@ -8,7 +8,7 @@ use Contao\Rector\ValueObject\ConstantToServiceParameter;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -28,14 +28,15 @@ final class ConstantToServiceParameterRector extends AbstractRector implements C
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated constants to service parameters', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $projectDir = TL_ROOT;
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
 $projectDir = \Contao\System::getContainer()->getParameter('kernel.project_dir');
-CODE_AFTER
+CODE_AFTER,
+                [new ConstantToServiceParameter('TL_ROOT', 'kernel.project_dir')]
             ),
         ]);
     }

--- a/src/Rector/LegacyFrameworkCallToInstanceCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToInstanceCallRector.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Rector;
 
+use Contao\Controller;
+use Contao\Database;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToInstanceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -27,7 +29,7 @@ final class LegacyFrameworkCallToInstanceCallRector extends AbstractLegacyFramew
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated legacy framework method to static calls', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $ids = \Contao\Controller::getChildRecords([42], 'tl_page');
 $ids = \Contao\Controller::getParentRecords(42, 'tl_page');
@@ -36,7 +38,8 @@ CODE_BEFORE
                 <<<'CODE_AFTER'
 $ids = \Contao\Database::getInstance()->getChildRecords([42], 'tl_page');
 $ids = \Contao\Database::getInstance()->getParentRecords(42, 'tl_page');
-CODE_AFTER
+CODE_AFTER,
+                [new LegacyFrameworkCallToInstanceCall(Controller::class, 'getChildRecords', Database::class, 'getChildRecords'),]
             ),
         ]);
     }

--- a/src/Rector/LegacyFrameworkCallToServiceCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToServiceCallRector.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Rector;
 
+use Contao\Controller;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToServiceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -27,14 +28,15 @@ final class LegacyFrameworkCallToServiceCallRector extends AbstractLegacyFramewo
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated legacy framework method to service calls', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $buffer = $this->parseSimpleTokens($buffer, $arrTokens);
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
 $buffer = \Contao\System::getContainer()->get('contao.string.simple_token_parser')->parse($buffer, $arrTokens);
-CODE_AFTER
+CODE_AFTER,
+                [new LegacyFrameworkCallToServiceCall(Controller::class, 'parseSimpleTokens', 'contao.string.simple_token_parser', 'parse')]
             ),
         ]);
     }

--- a/src/Rector/LegacyFrameworkCallToStaticCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToStaticCallRector.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Rector;
 
+use Contao\Backend;
+use Contao\Controller;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToStaticCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -27,7 +29,7 @@ final class LegacyFrameworkCallToStaticCallRector extends AbstractLegacyFramewor
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated legacy framework method to static calls', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_BEFORE'
 $html = \Contao\Controller::getImage($image, $width, $height);
 $html = $this->getImage($image, $width, $height);
@@ -36,7 +38,8 @@ CODE_BEFORE
                 <<<'CODE_AFTER'
 $html = \Contao\Image::get($image, $width, $height);
 $html = \Contao\Image::get($image, $width, $height);
-CODE_AFTER
+CODE_AFTER,
+                [new LegacyFrameworkCallToStaticCall(Controller::class, 'getTheme', Backend::class, 'getTheme')]
             ),
         ]);
     }


### PR DESCRIPTION
### Description

Adds a rule overview to all existing rectors that is generated using `symplify/rule-doc-generator`

*Might need to work on the CS if it's not okay for the rules* 

____

### Example

See: https://github.com/contao/contao-rector/pull/11/files#diff-24d468560b042cbed185f3af4324207b6505bf56533593ec251dd377bd8e1ba7

# 12 Rules Overview

## ConstantToClassConstantRector

Fixes deprecated constants to class constants

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\ConstantToClassConstantRector`](../src/Rector/ConstantToClassConstantRector.php)

```diff
-$logLevel = TL_ACCESS;
+$logLevel = \Contao\CoreBundle\Monolog\ContaoContext::ACCESS;
```

<br>

## ConstantToServiceCallRector

Fixes deprecated constants to service calls

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\ConstantToServiceCallRector`](../src/Rector/ConstantToServiceCallRector.php)

```diff
-$requestToken = REQUEST_TOKEN;
+$requestToken = \Contao\System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
```

<br>

## ConstantToServiceParameterRector

Fixes deprecated constants to service parameters

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\ConstantToServiceParameterRector`](../src/Rector/ConstantToServiceParameterRector.php)

```diff
-$projectDir = TL_ROOT;
+$projectDir = \Contao\System::getContainer()->getParameter('kernel.project_dir');
```

<br>

## ControllerMethodToVersionsClassRector

Fixes deprecated `Controller::createInitialVersion()` and `Controller::createNewVersion()` to Versions class calls

- class: [`Contao\Rector\Rector\ControllerMethodToVersionsClassRector`](../src/Rector/ControllerMethodToVersionsClassRector.php)

```diff
-\Contao\Controller::createInitialVersion('tl_page', 17);
-\Contao\Controller::createNewVersion('tl_page', 17);
+(new \Contao\Versions('tl_page', 17))->initialize();
+(new \Contao\Versions('tl_page', 17))->create();
```

<br>

## InsertTagsServiceRector

Fixes deprecated `Controller::replaceInsertTags()` to service calls

- class: [`Contao\Rector\Rector\InsertTagsServiceRector`](../src/Rector/InsertTagsServiceRector.php)

```diff
-$buffer = \Contao\Controller::replaceInsertTags($buffer);
-$uncached = \Contao\Controller::replaceInsertTags($buffer, false);
-$class = (new \Contao\InsertTags())->replace($buffer);
+$buffer = \Contao\System::getContainer('contao.insert_tags.parser')->replace($buffer);
+$uncached = \Contao\System::getContainer('contao.insert_tags.parser')->replaceInline($buffer);
+$class = \Contao\System::getContainer('contao.insert_tags.parser')->replace($buffer);
```

<br>

## LegacyFrameworkCallToInstanceCallRector

Fixes deprecated legacy framework method to static calls

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\LegacyFrameworkCallToInstanceCallRector`](../src/Rector/LegacyFrameworkCallToInstanceCallRector.php)

```diff
-$ids = \Contao\Controller::getChildRecords([42], 'tl_page');
-$ids = \Contao\Controller::getParentRecords(42, 'tl_page');
+$ids = \Contao\Database::getInstance()->getChildRecords([42], 'tl_page');
+$ids = \Contao\Database::getInstance()->getParentRecords(42, 'tl_page');
```

<br>

## LegacyFrameworkCallToServiceCallRector

Fixes deprecated legacy framework method to service calls

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\LegacyFrameworkCallToServiceCallRector`](../src/Rector/LegacyFrameworkCallToServiceCallRector.php)

```diff
-$buffer = $this->parseSimpleTokens($buffer, $arrTokens);
+$buffer = \Contao\System::getContainer()->get('contao.string.simple_token_parser')->parse($buffer, $arrTokens);
```

<br>

## LegacyFrameworkCallToStaticCallRector

Fixes deprecated legacy framework method to static calls

:wrench: **configure it!**

- class: [`Contao\Rector\Rector\LegacyFrameworkCallToStaticCallRector`](../src/Rector/LegacyFrameworkCallToStaticCallRector.php)

```diff
-$html = \Contao\Controller::getImage($image, $width, $height);
-$html = $this->getImage($image, $width, $height);
+$html = \Contao\Image::get($image, $width, $height);
+$html = \Contao\Image::get($image, $width, $height);
```

<br>

## LoginConstantsToSymfonySecurityRector

Fixes deprecated login constants to security service call

- class: [`Contao\Rector\Rector\LoginConstantsToSymfonySecurityRector`](../src/Rector/LoginConstantsToSymfonySecurityRector.php)

```diff
-$hasFrontendAccess = FE_USER_LOGGED_IN;
-$hasBackendAccess = BE_USER_LOGGED_IN;
+$hasFrontendAccess = \Contao\System::getContainer()->get('security.helper')->isGranted('ROLE_MEMBER');
+$hasBackendAccess = \Contao\System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
```

<br>

## ModeConstantToScopeMatcherRector

Fixes deprecated TL_MODE constant to service call

- class: [`Contao\Rector\Rector\ModeConstantToScopeMatcherRector`](../src/Rector/ModeConstantToScopeMatcherRector.php)

```diff
-$isBackend = TL_MODE === 'BE';
+$isBackend = \Contao\System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(\Contao\System::getContainer()->get('request_stack')->getCurrentRequest() ?? \Symfony\Component\HttpFoundation\Request::create(''));
```

<br>

## SystemLanguagesToServiceRector

Fixes deprecated `\Contao\System::getLanguages()` method to service call

- class: [`Contao\Rector\Rector\SystemLanguagesToServiceRector`](../src/Rector/SystemLanguagesToServiceRector.php)

```diff
-$languaegs = \Contao\System::getLanguages();
+$languages = \Contao\System::getContainer()->get('contao.intl.locales')->getLocales(null, true);
```

<br>

## SystemLogToMonologRector

Rewrites deprecated `System::log()` calls to Monolog

- class: [`Contao\Rector\Rector\SystemLogToMonologRector`](../src/Rector/SystemLogToMonologRector.php)

```diff
-\Contao\System::log('generic log message', __METHOD__, TL_ACCESS);
-\Contao\System::log('error message', __METHOD__, TL_ERROR);
+\Contao\System::getContainer()->get('logger')->log(\Psr\Log\LogLevel::INFO, 'generic log message', ['contao' => new \Contao\CoreBundle\Monolog\ContaoContext(__METHOD__, \Contao\CoreBundle\Monolog\ContaoContext::ACCESS)]);
+\Contao\System::getContainer()->get('logger')->log(\Psr\Log\LogLevel::ERROR, 'error message', ['contao' => new \Contao\CoreBundle\Monolog\ContaoContext(__METHOD__, \Contao\CoreBundle\Monolog\ContaoContext::ERROR)]);
```

<br>