### PR TITLE
Add missing tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rector Rules for Contao Open Source CMS
 
-This project contains [Rector rules](https://github.com/rectorphp/rector) for [Contao Open Source CMS](https://contao/contao) upgrades.
+This project contains [Rector rules](https://github.com/rectorphp/rector)
+for [Contao Open Source CMS](https://contao/contao) upgrades.
 
 **!! WARNING !! this is currently experimental, use at your own risk**
 
@@ -14,21 +15,13 @@ composer require contao/contao-rector --dev
 
 ## Available sets
 
-**ContaoSetList::CONTAO_49**  
-updates your code to compatibility with Contao 4.9
-
-**ContaoSetList::CONTAO_413**  
-updates your code to compatibility with Contao 4.13
-
-**ContaoSetList::CONTAO_50**  
-updates your code to compatibility with Contao 5.0
-
-**ContaoSetList::ANNOTATIONS_TO_ATTRIBUTES**  
-converts Contao annotations (e.g. `@Hook("...")`) to attributes (e.g. `#[AsHook('...')]`)
-
-**ContaoSetList::FQCN**  
-upgrades class namespaces from global (e.g. `\StringUtil`) to Contao (e.g. `\Contao\StringUtil`)
-
+| Sets                                           | Description                                                                                      |
+|:-----------------------------------------------|:-------------------------------------------------------------------------------------------------|
+| ```ContaoSetList::CONTAO_49```                 | updates your code to compatibility with Contao 4.9                                               |
+| ```ContaoSetList::CONTAO_413```                | updates your code to compatibility with Contao 4.13                                              |
+| ```ContaoSetList::CONTAO_50```                 | updates your code to compatibility with Contao 5.0                                               |
+| ```ContaoSetList::ANNOTATIONS_TO_ATTRIBUTES``` | converts Contao annotations (e.g. `@Hook("...")`) to attributes (e.g. `#[AsHook('...')]`)        |
+| ```ContaoSetList::FQCN```                      | upgrades class namespaces from global (e.g. `\StringUtil`) to Contao (e.g. `\Contao\StringUtil`) |
 
 ## Available level sets
 
@@ -41,3 +34,11 @@ to PHP 7.4 and Symfony 5.4, since Contao 4.13 does not support any lower version
 ## Available rules
 
 * [Explore the current Rector rules](/docs/rules_overview.md)
+
+### Development
+
+You can generate the rules with the following command:
+
+```shell
+vendor/bin/rule-doc-generator generate src/Rector --output-file docs/rules_overview.md
+```

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,4 +1,4 @@
-# 12 Rules Overview
+# 13 Rules Overview
 
 ## ConstantToClassConstantRector
 
@@ -41,6 +41,19 @@ Fixes deprecated constants to service parameters
 ```diff
 -$projectDir = TL_ROOT;
 +$projectDir = \Contao\System::getContainer()->getParameter('kernel.project_dir');
+```
+
+<br>
+
+## ContainerSessionToRequestStackSessionRector
+
+Rewrites session access to the request stack session
+
+- class: [`Contao\Rector\Rector\ContainerSessionToRequestStackSessionRector`](../src/Rector/ContainerSessionToRequestStackSessionRector.php)
+
+```diff
+-\Contao\System::getContainer()->get('session');
++\Contao\System::getContainer()->get('request_stack')->getSession();
 ```
 
 <br>

--- a/tests/Rector/ContainerSessionToRequestStackSessionRector/ContainerSessionToRequestStackSessionRectorTest.php
+++ b/tests/Rector/ContainerSessionToRequestStackSessionRector/ContainerSessionToRequestStackSessionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Tests\Rector\ContainerSessionToRequestStackSessionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContainerSessionToRequestStackSessionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/ContainerSessionToRequestStackSessionRector/config/config.php
+++ b/tests/Rector/ContainerSessionToRequestStackSessionRector/config/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\Rector\Rector\ContainerSessionToRequestStackSessionRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ContainerSessionToRequestStackSessionRector::class);
+};

--- a/tests/Rector/ContainerSessionToRequestStackSessionRector/fixture/session.php.inc
+++ b/tests/Rector/ContainerSessionToRequestStackSessionRector/fixture/session.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $session = \Contao\System::getContainer()->get('session');
+    }
+}
+?>
+-----
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $session = \Contao\System::getContainer()->get('request_stack')->getSession();
+    }
+}
+?>


### PR DESCRIPTION
### Description

This PR is more of a chore and adds:

* missing tests for the newly introduced `ContainerSessionToRequestStackSessionRector` introduced in 7f76830fcf98d0d744b6800151454954c0745ec2 -> See: 901c9b9734fd4003656c2c26e7d7da60ed3131b8

* Updates the readme to change the visuals and includes a hint on how to generate the `rules_overview` documentation 4cab1b711f4aed52975a619ba5fc042b336593d0
    
    ![image](https://github.com/user-attachments/assets/91494eb7-d3e4-4f5b-b4a2-e5cb09c07acb)

* Updates the `rules_overview` 97b1615bdefdad1cb26fafaf5fea207397b3af78

