### PR TITLE
Prepare to Rector next 2.0 with PHPStan 2 and PHPParser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "rector/rector": "^0.19 || ^1.0",
-        "phpstan/phpstan": "^1.0",
+        "rector/rector": "dev-main as 1.2.10",
+        "phpstan/phpstan": "^2.0",
         "webmozart/assert": "^1.7"
     },
     "require-dev": {
@@ -41,5 +41,11 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "php-http/discovery": true
+        }
+    }
 }

--- a/tests/Rector/ModeConstantToScopeMatcherRector/fixture/is_not_identical_backend.php.inc
+++ b/tests/Rector/ModeConstantToScopeMatcherRector/fixture/is_not_identical_backend.php.inc
@@ -1,4 +1,3 @@
-
 <?php
 
 use Contao\Controller;


### PR DESCRIPTION
Rector is upgrading to PHPStan 2 and PHPParser 5 at PR:

- https://github.com/rectorphp/rector-src/pull/6431

this PR upgrade for compatiblity syntax.