### PR TITLE
Upgrade to RectorPHP in version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "rector/rector": "^0.19 || ^1.0",
-        "phpstan/phpstan": "^1.0",
+        "rector/rector": "dev-main as 1.2.10",
+        "phpstan/phpstan": "^2.0",
         "webmozart/assert": "^1.7"
     },
     "require-dev": {
@@ -41,5 +41,11 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "php-http/discovery": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,5 @@
         "test": "vendor/bin/phpunit"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "allow-plugins": {
-            "contao-components/installer": true,
-            "php-http/discovery": true
-        }
-    }
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "rector/rector": "dev-main as 1.2.10",
+        "rector/rector": "^2.0",
         "phpstan/phpstan": "^2.0",
         "webmozart/assert": "^1.7"
     },

--- a/src/Set/ContaoLevelSetList.php
+++ b/src/Set/ContaoLevelSetList.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class ContaoLevelSetList implements SetListInterface
+final class ContaoLevelSetList
 {
     /**
      * @var string

--- a/src/Set/ContaoSetList.php
+++ b/src/Set/ContaoSetList.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class ContaoSetList implements SetListInterface
+final class ContaoSetList
 {
     /**
      * @var string

--- a/tests/Rector/ModeConstantToScopeMatcherRector/fixture/is_not_identical_backend.php.inc
+++ b/tests/Rector/ModeConstantToScopeMatcherRector/fixture/is_not_identical_backend.php.inc
@@ -1,4 +1,3 @@
-
 <?php
 
 use Contao\Controller;


### PR DESCRIPTION
### Description

* supersedes #15 

Whilst #15 was already preparing for the dev release, this PR aims to unlock RectorPHP 2 completely.

(This also removes the SetListInterface that was deprecated in v1)