### PR TITLE
Check whether the early return matches the configured target path

### DIFF
--- a/src/Rector/ReplaceNestedArrayItemRector.php
+++ b/src/Rector/ReplaceNestedArrayItemRector.php
@@ -147,6 +147,21 @@ CODE_AFTER
         // Early return because we are already at the end of the path
         if (self::PATH_END === $childTraversalPath)
         {
+            // Array length differs thus not a real match
+            if (count($targetPath) !== count($parentPath))
+            {
+                return [];
+            }
+
+            // Match against the target path
+            foreach ($targetPath as $index => $value)
+            {
+                if ('*' !== $value && $value !== $parentPath[$index])
+                {
+                    return [];
+                }
+            }
+
             return [$parentPath];
         }
 

--- a/tests/Rector/ReplaceNestedArrayItemRector/fixture/model.php.inc
+++ b/tests/Rector/ReplaceNestedArrayItemRector/fixture/model.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+        $arrOptions['limit'] = 1;
+    }
+}
+?>
+-----
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+        $arrOptions['limit'] = 1;
+    }
+}
+?>


### PR DESCRIPTION
### Description

Whilst running it against a large codebase, I realized that something like this:
```php
        new ReplaceNestedArrayItemValue(
            'TL_DCA.*.fields.*.flag',
            1,
            new ClassConstFetch(new FullyQualified(DataContainer::class), 'SORT_INITIAL_LETTER_ASC')
        ),
```

would also affect this due to how the early return was handled in matching paths.
```diff
-$arrOptions['limit'] = 1;
+$arrOptions['limit'] = DataContainer::SORT_INITIAL_LETTER_ASC;
```

This should now check whether a final array item as an expression value matches the given target path in the configuration