### PR TITLE
Add a `StringReplaceRector`

### DIFF
--- a/config/sets/contao/contao-53.php
+++ b/config/sets/contao/contao-53.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\Rector\Rector\StringReplaceRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
@@ -10,5 +11,10 @@ use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RenameClassConstFetchRector::class, [
         new RenameClassAndConstFetch(ContaoCorePermissions::class, 'USER_CAN_ACCESS_FORM', ContaoCorePermissions::class, 'USER_CAN_EDIT_FORM'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(StringReplaceRector::class, [
+        '_legend:hide}',
+        '_legend:collapsed}'
     ]);
 };

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,4 +1,4 @@
-# 14 Rules Overview
+# 15 Rules Overview
 
 ## ConstantToClassConstantRector
 
@@ -192,6 +192,21 @@ Replaces array item values based on a configuration with wild card support and s
          ],
      ]
  ];
+```
+
+<br>
+
+## StringReplaceRector
+
+Replaces text occurrences within a string
+
+:wrench: **configure it!**
+
+- class: [`Contao\Rector\Rector\StringReplaceRector`](../src/Rector/StringReplaceRector.php)
+
+```diff
+-$foo = '{foo_legend},foo;{bar_legend:hide},bar;{baz_legend:hide},baz';
++$foo = '{foo_legend},foo;{bar_legend:collapsed},bar;{baz_legend:collapsed},baz';
 ```
 
 <br>

--- a/src/Rector/StringReplaceRector.php
+++ b/src/Rector/StringReplaceRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class StringReplaceRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
+{
+    private array $configuration = [];
+
+    public function configure(array $configuration): void
+    {
+        Assert::allString($configuration);
+        Assert::count($configuration, 2);
+        Assert::uniqueValues($configuration);
+
+        $this->configuration = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replaces text occurrences within a string', [
+            new ConfiguredCodeSample(
+                <<<'CODE_BEFORE'
+$foo = '{foo_legend},foo;{bar_legend:hide},bar;{baz_legend:hide},baz';
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$foo = '{foo_legend},foo;{bar_legend:collapsed},bar;{baz_legend:collapsed},baz';
+CODE_AFTER,
+                ['_legend:hide}', '_legend:collapsed}']
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [String_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof String_);
+
+        if (false === strpos($node->value, $this->configuration[0])) {
+            return null;
+        }
+
+        $newValue = str_replace($this->configuration[0], $this->configuration[1], $node->value);
+
+        if ($node->value !== $newValue) {
+            return null;
+        }
+
+        return new String_($newValue);
+    }
+}

--- a/src/Rector/StringReplaceRector.php
+++ b/src/Rector/StringReplaceRector.php
@@ -57,7 +57,7 @@ CODE_AFTER,
 
         $newValue = str_replace($this->configuration[0], $this->configuration[1], $node->value);
 
-        if ($node->value !== $newValue) {
+        if ($node->value === $newValue) {
             return null;
         }
 

--- a/tests/Rector/StringReplaceRector/StringReplaceRectorTest.php
+++ b/tests/Rector/StringReplaceRector/StringReplaceRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\Rector\Tests\Rector\DefaultRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StringReplaceRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/StringReplaceRector/config/config.php
+++ b/tests/Rector/StringReplaceRector/config/config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\Rector\Rector\StringReplaceRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(StringReplaceRector::class, [
+        '_legend:hide}',
+        '_legend:collapsed}'
+    ]);
+};

--- a/tests/Rector/StringReplaceRector/fixture/dca.php.inc
+++ b/tests/Rector/StringReplaceRector/fixture/dca.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $GLOBALS['TL_DCA']['tl_content']['palettes']['foo'] = '{foo_legend},foo;{bar_legend:hide},bar;{baz_legend:hide},baz';
+    }
+}
+?>
+-----
+<?php
+
+class Foo extends Controller
+{
+    public function bar()
+    {
+        $GLOBALS['TL_DCA']['tl_content']['palettes']['foo'] = '{foo_legend},foo;{bar_legend:collapsed},bar;{baz_legend:collapsed},baz';
+    }
+}
+?>


### PR DESCRIPTION
### Description

basically this for the change from `:hide` to `:collapsed` as we are internally changing it here since 
https://github.com/contao/contao/blob/7d71ed920b7e95bdd6c6cf7568209e027bdff457/core-bundle/contao/drivers/DC_File.php#L178-#L184

```php
$rectorConfig->ruleWithConfiguration(StringReplaceRector::class, [
     '_legend:hide}',
     '_legend:collapsed}'
 ]);
```


```diff
-$foo = '{foo_legend},foo;{bar_legend:hide},bar;{baz_legend:hide},baz';
+$foo = '{foo_legend},foo;{bar_legend:collapsed},bar;{baz_legend:collapsed},baz';
```