### PR TITLE
Implement the `DocumentedRuleInterface` for rule generation

### DIFF
--- a/src/Rector/ConstantToClassConstantRector.php
+++ b/src/Rector/ConstantToClassConstantRector.php
@@ -9,11 +9,12 @@ use Contao\Rector\ValueObject\ConstantToClassConstant;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class ConstantToClassConstantRector extends AbstractRector implements ConfigurableRectorInterface
+final class ConstantToClassConstantRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array<ConstantToClassConstant>

--- a/src/Rector/ConstantToServiceCallRector.php
+++ b/src/Rector/ConstantToServiceCallRector.php
@@ -7,11 +7,12 @@ namespace Contao\Rector\Rector;
 use Contao\Rector\ValueObject\ConstantToServiceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class ConstantToServiceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface
+final class ConstantToServiceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array<ConstantToServiceCall>

--- a/src/Rector/ConstantToServiceParameterRector.php
+++ b/src/Rector/ConstantToServiceParameterRector.php
@@ -8,11 +8,12 @@ use Contao\Rector\ValueObject\ConstantToServiceParameter;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class ConstantToServiceParameterRector extends AbstractRector implements ConfigurableRectorInterface
+final class ConstantToServiceParameterRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array<ConstantToServiceParameter>

--- a/src/Rector/ContainerSessionToRequestStackSessionRector.php
+++ b/src/Rector/ContainerSessionToRequestStackSessionRector.php
@@ -8,10 +8,11 @@ use PhpParser\Node;
 use PHPStan\Type\ObjectType;
 use Psr\Container\ContainerInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ContainerSessionToRequestStackSessionRector extends AbstractRector
+final class ContainerSessionToRequestStackSessionRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ControllerMethodToVersionsClassRector.php
+++ b/src/Rector/ControllerMethodToVersionsClassRector.php
@@ -6,10 +6,11 @@ namespace Contao\Rector\Rector;
 
 use Contao\Controller;
 use PhpParser\Node;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ControllerMethodToVersionsClassRector extends AbstractLegacyFrameworkCallRector
+final class ControllerMethodToVersionsClassRector extends AbstractLegacyFrameworkCallRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/InsertTagsServiceRector.php
+++ b/src/Rector/InsertTagsServiceRector.php
@@ -7,10 +7,11 @@ namespace Contao\Rector\Rector;
 use Contao\Controller;
 use Contao\InsertTags;
 use PhpParser\Node;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class InsertTagsServiceRector extends AbstractLegacyFrameworkCallRector
+final class InsertTagsServiceRector extends AbstractLegacyFrameworkCallRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/LegacyFrameworkCallToInstanceCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToInstanceCallRector.php
@@ -9,11 +9,12 @@ use Contao\Database;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToInstanceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class LegacyFrameworkCallToInstanceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface
+final class LegacyFrameworkCallToInstanceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var LegacyFrameworkCallToInstanceCall[]

--- a/src/Rector/LegacyFrameworkCallToServiceCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToServiceCallRector.php
@@ -8,11 +8,12 @@ use Contao\Controller;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToServiceCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class LegacyFrameworkCallToServiceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface
+final class LegacyFrameworkCallToServiceCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array<LegacyFrameworkCallToServiceCall>

--- a/src/Rector/LegacyFrameworkCallToStaticCallRector.php
+++ b/src/Rector/LegacyFrameworkCallToStaticCallRector.php
@@ -9,11 +9,12 @@ use Contao\Controller;
 use Contao\Rector\ValueObject\LegacyFrameworkCallToStaticCall;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class LegacyFrameworkCallToStaticCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface
+final class LegacyFrameworkCallToStaticCallRector extends AbstractLegacyFrameworkCallRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var LegacyFrameworkCallToStaticCall[]

--- a/src/Rector/LoginConstantsToSymfonySecurityRector.php
+++ b/src/Rector/LoginConstantsToSymfonySecurityRector.php
@@ -13,10 +13,11 @@ use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\ConstFetch;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class LoginConstantsToSymfonySecurityRector extends AbstractRector
+final class LoginConstantsToSymfonySecurityRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ModeConstantToScopeMatcherRector.php
+++ b/src/Rector/ModeConstantToScopeMatcherRector.php
@@ -15,10 +15,11 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\Constant\ConstantStringType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ModeConstantToScopeMatcherRector extends AbstractRector
+final class ModeConstantToScopeMatcherRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ReplaceNestedArrayItemRector.php
+++ b/src/Rector/ReplaceNestedArrayItemRector.php
@@ -20,11 +20,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
-final class ReplaceNestedArrayItemRector extends AbstractRector implements ConfigurableRectorInterface
+final class ReplaceNestedArrayItemRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     const PATH_END = '__end__';
 

--- a/src/Rector/SystemLanguagesToServiceRector.php
+++ b/src/Rector/SystemLanguagesToServiceRector.php
@@ -6,10 +6,11 @@ namespace Contao\Rector\Rector;
 
 use Contao\System;
 use PhpParser\Node;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class SystemLanguagesToServiceRector extends AbstractLegacyFrameworkCallRector
+final class SystemLanguagesToServiceRector extends AbstractLegacyFrameworkCallRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/SystemLogToMonologRector.php
+++ b/src/Rector/SystemLogToMonologRector.php
@@ -8,10 +8,11 @@ use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\System;
 use PhpParser\Node;
 use Psr\Log\LogLevel;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class SystemLogToMonologRector extends AbstractLegacyFrameworkCallRector
+final class SystemLogToMonologRector extends AbstractLegacyFrameworkCallRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {


### PR DESCRIPTION
### Description

Since Rector 2, you do not need to use `getRuleDefinition` anymore, however we do have custom rules that are documented so this applies the interface for the rule generation 🙃.

I did not add it to the `AbstractLegacyFrameworkCallRector` so we can extend it in the future and be lazy not writing a rule definition :D 