### PR TITLE
Rector `System::getCountries` to a method call

### DIFF
--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -35,11 +35,13 @@ use Contao\System;
 use Patchwork\Utf8;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
-use Rector\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
@@ -97,6 +99,26 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Contao 4.12
     $rectorConfig->rule(SystemLanguagesToServiceRector::class);
+    $rectorConfig->ruleWithConfiguration(ReplaceNestedArrayItemRector::class, [
+        new ReplaceNestedArrayItemValue(
+            'TL_DCA.*.fields.*.options',
+            new StaticCall(new FullyQualified(System::class), 'getCountries'),
+            new FuncCall(
+                new Name('array_change_key_case'), [
+                    new Arg(
+                        new MethodCall(
+                            new MethodCall(
+                                new StaticCall(new FullyQualified(System::class), 'getContainer'),
+                                'get',
+                                [new Arg(new String_('contao.intl.countries'))]
+                            ),
+                            'getCountries'
+                        )
+                    )
+                ]
+            )
+        )
+    ]);
 
     // Contao 4.13
     $rectorConfig->rule(InsertTagsServiceRector::class);

--- a/src/Rector/ReplaceNestedArrayItemRector.php
+++ b/src/Rector/ReplaceNestedArrayItemRector.php
@@ -8,7 +8,6 @@ use Contao\Config;
 use Contao\Rector\ValueObject\ReplaceNestedArrayItemValue;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ArrayItem;
@@ -311,6 +310,7 @@ CODE_AFTER
 
                     elseif (
                         [] === $childrenKeyPath
+                        && $sub->key->value === array_values($childrenKeyPath)[0] ?? null
                         && $this->matchesReplacementValue($sub, $oldValue)
                     ) {
                         $sub = $newValue;

--- a/src/Rector/ReplaceNestedArrayItemRector.php
+++ b/src/Rector/ReplaceNestedArrayItemRector.php
@@ -302,7 +302,7 @@ CODE_AFTER
                 ) {
                     if (
                         [] !== $childrenKeyPath
-                        && $sub->key->value === array_values($childrenKeyPath)[0] ?? null
+                        && $sub->key->value === (array_values($childrenKeyPath)[0] ?? null)
                     ) {
                         array_shift($childrenKeyPath);
                         $this->replaceTargetNodeValue($sub, $childrenKeyPath, $configuration, $oldValue, $newValue);
@@ -310,7 +310,7 @@ CODE_AFTER
 
                     elseif (
                         [] === $childrenKeyPath
-                        && $sub->key->value === array_values($childrenKeyPath)[0] ?? null
+                        && $sub->key->value === (array_values($childrenKeyPath)[0] ?? null)
                         && $this->matchesReplacementValue($sub, $oldValue)
                     ) {
                         $sub = $newValue;

--- a/tests/Rector/ReplaceNestedArrayItemRector/config/config.php
+++ b/tests/Rector/ReplaceNestedArrayItemRector/config/config.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 use Contao\DataContainer;
 use Contao\Rector\Rector\ReplaceNestedArrayItemRector;
 use Contao\Rector\ValueObject\ReplaceNestedArrayItemValue;
+use Contao\System;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Config\RectorConfig;
@@ -29,5 +33,24 @@ return static function (RectorConfig $rectorConfig): void {
             1,
             new ClassConstFetch(new FullyQualified(DataContainer::class), 'SORT_INITIAL_LETTER_ASC')
         ),
+
+        new ReplaceNestedArrayItemValue(
+            'TL_DCA.*.fields.*.options',
+            new StaticCall(new FullyQualified(System::class), 'getCountries'),
+            new FuncCall(
+                new Name('array_change_key_case'), [
+                    new Arg(
+                        new MethodCall(
+                            new MethodCall(
+                                new StaticCall(new FullyQualified(System::class), 'getContainer'),
+                                'get',
+                                [new Arg(new String_('contao.intl.countries'))]
+                            ),
+                            'getCountries'
+                        )
+                    )
+                ]
+            )
+        )
     ]);
 };

--- a/tests/Rector/ReplaceNestedArrayItemRector/fixture/dca2.php.inc
+++ b/tests/Rector/ReplaceNestedArrayItemRector/fixture/dca2.php.inc
@@ -500,7 +500,7 @@ class Foo
                     'filter'                => true,
                     'sorting'               => true,
                     'inputType'             => 'select',
-                    'options'               => \Contao\System::getCountries(),
+                    'options'               => array_change_key_case(\Contao\System::getContainer()->get('contao.intl.countries')->getCountries()),
                     'eval'                  => array('mandatory'=>true, 'feEditable'=>true, 'feGroup'=>'address', 'tl_class'=>'w50', 'chosen'=>true),
                     'sql'                   => "varchar(32) NOT NULL default ''",
                 ),


### PR DESCRIPTION
### Description

* Implements #20 using the `ReplaceNestedArrayItemValueRector`

### Changes in the `ReplaceNestedArrayItemValueRector`
Mind that there was one change in the `ReplaceNestedArrayItemValueRector` where the Rector would change the AST when visiting it using the NodeVisitor down the line when calling `matchesReplacementValue()` and `normalizeNode()`.
It basically normalized all arrays that could have been part of a specific rector changing values such as `true` to `\true` (Name to FullyQualifiedName). This has now been fixed.

TLDR; - The NodeVisitor within the NodeTraverser replaces stuff in the `ReplaceNestedArrayItemValueRector` so we only want that to happen when the actual value matches our configuration :D
