### PR TITLE
Remove use of protected property NodeNameResolver on ModeConstantToScopeMatcherRector

### DIFF
--- a/src/Rector/ModeConstantToScopeMatcherRector.php
+++ b/src/Rector/ModeConstantToScopeMatcherRector.php
@@ -51,7 +51,7 @@ CODE_AFTER
 
         if (
             !$left instanceof FuncCall
-            || !$this->nodeNameResolver->isName($left, 'defined')
+            || !$this->isName($left, 'defined')
             || 1 !== \count($left->getArgs())
             || !($arg = $left->getArgs()[0]->value)
             || !$arg instanceof String_


### PR DESCRIPTION
Rector is removing use of protected property `nodeNameResolver` in rules, use `isName()` directly instead. Ref PR:

- https://github.com/rectorphp/rector-src/pull/6875