### PR TITLE
Use `withComposerBased` instead of the deprecated SetList

### DIFF
--- a/config/sets/contao/level/up-to-contao-57.php
+++ b/config/sets/contao/level/up-to-contao-57.php
@@ -3,19 +3,13 @@
 declare(strict_types=1);
 
 use Contao\Rector\Set\ContaoLevelSetList;
-use Contao\Rector\Set\ContaoSetList;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
-use Rector\Symfony\Set\SymfonySetList;
 
 return RectorConfig::configure()
     ->withSets([
         ContaoLevelSetList::UP_TO_CONTAO_55,
         LevelSetList::UP_TO_PHP_83,
-        SymfonySetList::SYMFONY_70,
-        SymfonySetList::SYMFONY_71,
-        SymfonySetList::SYMFONY_72,
-        SymfonySetList::SYMFONY_73,
-        SymfonySetList::SYMFONY_74,
     ])
+    ->withComposerBased(symfony: true)
 ;


### PR DESCRIPTION
### Description

Seen that new level sets have been introduced in ccc403aa449ab40f36ddcbff44d6fb024178396b but the usage of SetList is discouraged and deprecated.

Since Rector 2 we can use composer based level set lists: https://getrector.com/blog/introducing-composer-version-based-sets
This PR changes it for the latest change right now making sure that the SetList is dependent on the composer.json.

/cc @aschempp this could be introduced in the other level sets in the future if needed. Wdyt?