### PR TITLE
Replace `TL_CSS_UNITS` global with array values

### DIFF
--- a/config/sets/contao/contao-413.php
+++ b/config/sets/contao/contao-413.php
@@ -34,10 +34,14 @@ use Contao\StringUtil;
 use Contao\System;
 use Patchwork\Utf8;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
@@ -167,6 +171,19 @@ return static function (RectorConfig $rectorConfig): void {
             'TL_DCA.*.fields.*.eval.extensions',
             new StaticCall(new FullyQualified(Config::class), 'get', [new Arg(new String_('validImageTypes'))]),
             '%contao.image.valid_extensions%'
+        ),
+
+        new ReplaceNestedArrayItemValue(
+            'TL_DCA.*.fields.*.options',
+            new ArrayDimFetch(new Variable('GLOBALS'),
+                new String_('TL_CSS_UNITS')
+            ),
+            new Array_([
+                new ArrayItem(new String_('px')),
+                new ArrayItem(new String_('%')),
+                new ArrayItem(new String_('em')),
+                new ArrayItem(new String_('rem')),
+            ]),
         )
     ]);
 

--- a/config/sets/contao/contao-50.php
+++ b/config/sets/contao/contao-50.php
@@ -6,13 +6,18 @@ use Contao\CoreBundle\Controller\ContentElement\AbstractContentElementController
 use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 use Contao\Rector\Rector\ChangeDerivateClassReturnTypeRector;
 use Contao\Rector\Rector\RemoveMethodCallRector;
+use Contao\Rector\Rector\ReplaceNestedArrayItemRector;
 use Contao\Rector\ValueObject\ChangeDerivateClassReturnType;
 use Contao\Rector\ValueObject\RemoveMethodCall;
+use Contao\Rector\ValueObject\ReplaceNestedArrayItemValue;
 use Contao\StringUtil;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
 use Symfony\Component\HttpFoundation\Response;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -51,6 +56,21 @@ return static function (RectorConfig $rectorConfig): void {
             'UnionType',
             new FullyQualified(Response::class),
         ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ReplaceNestedArrayItemRector::class, [
+        new ReplaceNestedArrayItemValue(
+            'TL_DCA.*.fields.*.options',
+            new Expr\ArrayDimFetch(new Expr\Variable('GLOBALS'),
+                new Scalar\String_('TL_CSS_UNITS')
+            ),
+            new Array_([
+                new Expr\ArrayItem(new Scalar\String_('px')),
+                new Expr\ArrayItem(new Scalar\String_('%')),
+                new Expr\ArrayItem(new Scalar\String_('em')),
+                new Expr\ArrayItem(new Scalar\String_('rem')),
+            ]),
+        )
     ]);
 
     // TODO: remove use of nl2br_pre

--- a/config/sets/contao/contao-50.php
+++ b/config/sets/contao/contao-50.php
@@ -6,18 +6,13 @@ use Contao\CoreBundle\Controller\ContentElement\AbstractContentElementController
 use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 use Contao\Rector\Rector\ChangeDerivateClassReturnTypeRector;
 use Contao\Rector\Rector\RemoveMethodCallRector;
-use Contao\Rector\Rector\ReplaceNestedArrayItemRector;
 use Contao\Rector\ValueObject\ChangeDerivateClassReturnType;
 use Contao\Rector\ValueObject\RemoveMethodCall;
-use Contao\Rector\ValueObject\ReplaceNestedArrayItemValue;
 use Contao\StringUtil;
-use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Scalar;
 use Symfony\Component\HttpFoundation\Response;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -56,21 +51,6 @@ return static function (RectorConfig $rectorConfig): void {
             'UnionType',
             new FullyQualified(Response::class),
         ),
-    ]);
-
-    $rectorConfig->ruleWithConfiguration(ReplaceNestedArrayItemRector::class, [
-        new ReplaceNestedArrayItemValue(
-            'TL_DCA.*.fields.*.options',
-            new Expr\ArrayDimFetch(new Expr\Variable('GLOBALS'),
-                new Scalar\String_('TL_CSS_UNITS')
-            ),
-            new Array_([
-                new Expr\ArrayItem(new Scalar\String_('px')),
-                new Expr\ArrayItem(new Scalar\String_('%')),
-                new Expr\ArrayItem(new Scalar\String_('em')),
-                new Expr\ArrayItem(new Scalar\String_('rem')),
-            ]),
-        )
     ]);
 
     // TODO: remove use of nl2br_pre


### PR DESCRIPTION
### Description

See https://github.com/contao/contao/issues/3663 and https://github.com/contao/contao/pull/3859

```diff
-			'options'                 => $GLOBALS['TL_CSS_UNITS'],
+			'options'                 => array('px', '%', 'em', 'rem'),
```