### PR TITLE
Remove Doctrine ORM 2.14 from Contao config

### DIFF
--- a/config/sets/contao/level/up-to-contao-53.php
+++ b/config/sets/contao/level/up-to-contao-53.php
@@ -12,7 +12,6 @@ return RectorConfig::configure()
     ->withSets([
         ContaoLevelSetList::UP_TO_CONTAO_51,
         ContaoSetList::CONTAO_53,
-        DoctrineSetList::DOCTRINE_ORM_214,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,


### PR DESCRIPTION
Removed Doctrine ORM set from the configuration as it leads to exception in rector 2.6.4.